### PR TITLE
[definitions] Add missing list depth in ed269 polygons and fix example applicability field

### DIFF
--- a/src/uas_standards/eurocae_ed269.py
+++ b/src/uas_standards/eurocae_ed269.py
@@ -59,9 +59,10 @@ class HorizontalProjectionType(str, Enum):
 
 class CircleOrPolygonType(ImplicitDict):
     type: HorizontalProjectionType
-    center: Optional[List[float]]  # 2 items
+    center: Optional[List[float]]  # 2 items. Coordinates: lat, lng
     radius: Optional[float]  # > 0
-    coordinates: Optional[List[List[float]]]  # min 4 items  # 2 items
+    coordinates: Optional[List[List[List[float]]]]  # List of polygons -> List of points: min 4 items -> Coordinates: lat, lng
+
 
 
 class UomDimensions(str, Enum):

--- a/tests/test_eurocae_ed269.json
+++ b/tests/test_eurocae_ed269.json
@@ -1,5 +1,5 @@
 {
-  "title": "UASZoneTestData 2022-10-16",
+  "title": "UASZoneTestData 2022-10-25",
   "description": "Sample data for Automated Testing development",
   "features": [
     {
@@ -70,7 +70,7 @@
         {
           "startDateTime": "2022-06-15T09:00:00.00Z",
           "endDateTime": "2023-06-15T09:00:00.00Z",
-          "permanent": "YES"
+          "permanent": "NO"
         }
       ],
       "zoneAuthority": [


### PR DESCRIPTION
This PR adds a missing `List` depth to represent the Polygons data in ED269 definition.
In addition, it fixes the test example since Permanent applicability field shall always be NO if dates are provided.