### PR TITLE
[f3548v21] Target interuss/astm-utm-protocol repo as submodule and regen apis files

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -6,7 +6,7 @@
 	url = https://github.com/uastech/standards
 [submodule "interfaces/astm/f3548/v21"]
 	path = interfaces/astm/f3548/v21
-	url = https://github.com/astm-utm/Protocol
+	url = https://github.com/interuss/astm-utm-protocol
 [submodule "interfaces/interuss/automated_testing"]
 	path = interfaces/interuss/automated_testing
 	url = https://github.com/interuss/automated_testing_interfaces


### PR DESCRIPTION
Step towards addressing interuss/dss#1078.
In order to write the test scenario we need the generated python models from the updated OpenAPI definition.
`make apis` was ran to regenerate the update python file.

Note that there are some CI tests failing, but I do not believe that is due to the content of this PR. I will have a look at that, but a review is still welcomed in the meantime.