### PR TITLE
[CI] Fix MacOS builds: pin v13 image

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -14,15 +14,16 @@ jobs:
   install-test:
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest, macos-13] # MacOS image v14 does not support Python versions 3.8 & 3.9
         python-version: ["3.8", "3.9"]
       max-parallel: 3
-    name: Python ${{ matrix.python-version }}
+    name: Python ${{ matrix.python-version }} on ${{ matrix.os }}
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: setup-python
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
         architecture: "x64"
@@ -35,15 +36,16 @@ jobs:
   editable-install-test:
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest, macos-13] # MacOS image v14 does not support Python version 3.8
         python-version: ["3.8"]
       max-parallel: 3
-    name: Python ${{ matrix.python-version }}
+    name: Python ${{ matrix.python-version }} on ${{ matrix.os }} (editable install)
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: setup-python
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
         architecture: "x64"


### PR DESCRIPTION
The latest MacOS image does not seem to support correctly anymore Python versions 3.8 & 3.9.
See notably actions/runner-images#9770.

This pins the MacOS image version to v13. In addition some slight CI enhancements:
- Clarify job names
- Bump checkout and setup-python actions versions
- Set to continue jobs on failures