### PR TITLE
Fix repository_url specification

### DIFF
--- a/.github/workflows/test_publish.yaml
+++ b/.github/workflows/test_publish.yaml
@@ -35,4 +35,4 @@ jobs:
       with:
         user: __token__
         password: ${{ secrets.TEST_PYPI_API_TOKEN }}
-        repository_url: https://test.pypi.org/legacy/
+        repository-url: https://test.pypi.org/legacy/


### PR DESCRIPTION
This PR attempts to fix a deprecated parameter specification that caused the [failure](https://github.com/interuss/uas_standards/actions/runs/11238601666/job/31243743208) of the release of 3.2.0.