### PR TITLE
[CI] Enable verbose logs for publishing to PyPi

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -35,3 +35,4 @@ jobs:
       with:
         user: __token__
         password: ${{ secrets.PYPI_API_TOKEN }}
+        verbose: true

--- a/.github/workflows/test_publish.yaml
+++ b/.github/workflows/test_publish.yaml
@@ -36,3 +36,4 @@ jobs:
         user: __token__
         password: ${{ secrets.TEST_PYPI_API_TOKEN }}
         repository-url: https://test.pypi.org/legacy/
+        verbose: true


### PR DESCRIPTION
Drafting this PR in order to trigger the CI to attempt publishing the package in order to debug the publishing issue.