### PR TITLE
[f3411/v22a/constants] Fix min & max track direction

### DIFF
--- a/src/uas_standards/astm/f3411/v22a/constants.py
+++ b/src/uas_standards/astm/f3411/v22a/constants.py
@@ -50,11 +50,11 @@ MinHeightResolution = 1
 SpecialHeight = -1000
 """Special value for height indicating Invalid, No Value or Unknown, according to definitions in Table 1."""
 
-MinTrackDirection = -359
-"""Minimum value for track direction, in degrees, according to definitions in Table 1."""
+MinTrackDirection = 0
+"""Minimum value (included) for track direction, in degrees, according to definitions in Table 1."""
 
-MaxTrackDirection = 359
-"""Maximum value for track direction, in degrees, according to definitions in Table 1."""
+MaxTrackDirection = 360
+"""Maximum value (excluded) for track direction, in degrees, according to definitions in Table 1."""
 
 SpecialTrackDirection = 361
 """Special value for track direction indicating Invalid, No Value or Unknown, according to definitions in Table 1."""

--- a/src/uas_standards/astm/f3411/v22a/constants.py
+++ b/src/uas_standards/astm/f3411/v22a/constants.py
@@ -51,7 +51,7 @@ SpecialHeight = -1000
 """Special value for height indicating Invalid, No Value or Unknown, according to definitions in Table 1."""
 
 MinTrackDirection = 0
-"""Minimum value (included) for track direction, in degrees, according to definitions in Table 1."""
+"""Minimum value (inclusive) for track direction, in degrees, according to OpenAPI specification."""
 
 MaxTrackDirection = 360
 """Maximum value (excluded) for track direction, in degrees, according to definitions in Table 1."""

--- a/src/uas_standards/astm/f3411/v22a/constants.py
+++ b/src/uas_standards/astm/f3411/v22a/constants.py
@@ -54,7 +54,7 @@ MinTrackDirection = 0
 """Minimum value (inclusive) for track direction, in degrees, according to OpenAPI specification."""
 
 MaxTrackDirection = 360
-"""Maximum value (excluded) for track direction, in degrees, according to definitions in Table 1."""
+"""Maximum value (exclusive) for track direction, in degrees, according to range described in Table 6.  The SpecialTrackDirection value is also allowed."""
 
 SpecialTrackDirection = 361
 """Special value for track direction indicating Invalid, No Value or Unknown, according to definitions in Table 1."""


### PR DESCRIPTION
## About minimum
Both v19 and v22a OpenAPI specifications set the minimum to 0, as such `MinTrackDirection` clearly seems ot be invalid.

## About maximum
What's the correct value for `MaxTrackDirection` is a bit more fuzzy to me.
v19 OpenAPI specs mention maximum of 360, excluded.
v22a OpenAPI specs mention maximum of 361, included. But it seems that's only to accommodate for the introduced special value 361.
My interpretation here is that a valid track direction belongs to `[0;360[`.

Discussed with @barroco and @the-glu : @BenjaminPelletier we'd appreciate your feedback on this PR.