### PR TITLE
Add some missing constants

### DIFF
--- a/src/uas_standards/astm/f3411/v22a/constants.py
+++ b/src/uas_standards/astm/f3411/v22a/constants.py
@@ -47,6 +47,9 @@ SpecialVerticalSpeed = 63
 MinHeightResolution = 1
 """Minimum resolution of height value, in meters, according to definitions in Table 1."""
 
+MinOperatorAltitudeResolution = 1
+"""Minimum resolution of operator altitude value, in meters, according to definitions in Table 1."""
+
 SpecialHeight = -1000
 """Special value for height indicating Invalid, No Value or Unknown, according to definitions in Table 1."""
 
@@ -64,3 +67,6 @@ MinTrackDirectionResolution = 1
 
 MinTimestampResolution = 0.1
 """Minimum resolution of timestamp value, in seconds, according to definitions in Table 1."""
+
+MinTimestampAccuracyResolution = 0.1
+"""Minimum resolution of timestamp accuracy value, in seconds, according to definitions in Table 1."""


### PR DESCRIPTION
This PR add some missing constants for https://github.com/interuss/monitoring/pull/977

One constants is not defined in the standard: the resolution of `Vertical Speed` is not defined. What should we do for value comparison?

- Use an arbitrary value of 0.25, like the normal speed
- Use an arbitrary value of 0.5, the resolution in table 6
- Use an arbitrary value of 0.1 
- Don't use a tolerance in tests and just use the float as himself.