### PR TITLE
Add brief script to retrieve InterUSS DSS aux interface

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,3 +11,4 @@ lint:
 	uv run ruff format --check
 	uv run ruff check
 	uv run --all-groups basedpyright
+	./tools/verify_sync.sh

--- a/interfaces/interuss/dss/aux/README.md
+++ b/interfaces/interuss/dss/aux/README.md
@@ -1,3 +1,1 @@
-This folder contains the `aux` interface definition from [the InterUSS DSS repository](https://github.com/interuss/dss), but the contents must be manually populated and updated.
-
-The current content was populated from the v0.21.1 release.
+This folder contains the `aux` interface definition from [the InterUSS DSS repository](https://github.com/interuss/dss), but the contents must be manually populated and updated by editing and running [`get_from_upstream.sh`](./get_from_upstream.sh).

--- a/interfaces/interuss/dss/aux/get_from_upstream.sh
+++ b/interfaces/interuss/dss/aux/get_from_upstream.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+OS=$(uname)
+if [[ $OS == "Darwin" ]]; then
+	# OSX uses BSD readlink
+	BASEDIR="$(dirname "$0")"
+else
+	BASEDIR=$(readlink -e "$(dirname "$0")")
+fi
+
+cd "${BASEDIR}" || exit
+
+# URL to raw content for this interface.  Should target pinned content: either a tag or commit.
+URL="https://raw.githubusercontent.com/interuss/dss/refs/tags/interuss/dss/v0.21.1/interfaces/aux_/aux_.yaml"
+
+wget -N $URL

--- a/tools/verify_sync.sh
+++ b/tools/verify_sync.sh
@@ -1,0 +1,69 @@
+#!/bin/bash
+
+OS=$(uname)
+if [[ $OS == "Darwin" ]]; then
+	# OSX uses BSD readlink
+	BASEDIR="$(dirname "$0")"
+else
+	BASEDIR=$(readlink -e "$(dirname "$0")")
+fi
+
+cd "${BASEDIR}/.." || exit
+
+# Format: ["path/to/update_script.sh"]="affected_file1.txt affected_file2.yaml dir/affected_file3.md"
+declare -A SCRIPT_MAP
+SCRIPT_MAP=(
+    ["./interfaces/interuss/dss/aux/get_from_upstream.sh"]="./interfaces/interuss/dss/aux/aux_.yaml"
+)
+
+get_checksums() {
+    local files=$1
+    md5sum $files 2>/dev/null
+}
+
+failed_scripts=()
+
+for script in "${!SCRIPT_MAP[@]}"; do
+    files=${SCRIPT_MAP[$script]}
+
+    echo "------------------------------------------------"
+    echo "Checking script: $script"
+    echo "Monitoring files: $files"
+
+    # 1. Capture initial state
+    pre_checksum=$(get_checksums "$files")
+
+    # 2. Run the script
+    if [[ -f "$script" ]]; then
+        chmod +x "$script"
+        echo "Running $script..."
+        ./"$script"
+    else
+        echo "Error: Script '$script' not found. Skipping."
+        failed_scripts+=("$script (Not Found)")
+        continue
+    fi
+
+    # 3. Capture post state
+    post_checksum=$(get_checksums "$files")
+
+    # 4. Compare
+    if [[ "$pre_checksum" == "$post_checksum" ]]; then
+        echo "Success: No monitored files were changed by $script."
+    else
+        echo "FAILURE: One or more files were modified by $script!"
+        failed_scripts+=("$script (Modified Files)")
+    fi
+done
+
+echo "------------------------------------------------"
+if [ ${#failed_scripts[@]} -eq 0 ]; then
+    echo "All checks passed! All files are in sync."
+    exit 0
+else
+    echo "The following operations needed to be performed to ensure files are in sync:"
+    for item in "${failed_scripts[@]}"; do
+        echo "  - $item"
+    done
+    exit 1
+fi


### PR DESCRIPTION
This PR adds a brief script as the title indicates in response to [this comment](https://github.com/interuss/uas_standards/pull/38#discussion_r3072086805).  It also adds a verify_sync.sh script that ensures this script has been run as a PR check via `make lint`.