### PR TITLE
Update DSS aux API

### DIFF
--- a/interfaces/interuss/dss/aux/aux_.yaml
+++ b/interfaces/interuss/dss/aux/aux_.yaml
@@ -82,7 +82,6 @@ components:
           type: string
           format: date-time
           example: '1985-04-12T23:45:00Z'
-          default: ''
       required:
       - timestamp
       - source
@@ -346,6 +345,22 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/SCDLockModeResponse'
+        '401':
+          description: >-
+            Bearer access token was not provided in Authorization header, token
+            could not be decoded, or token was invalid.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '403':
+          description: >-
+            The access token was decoded successfully but did not include a
+            scope appropriate to this endpoint.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
         '501':
           description: >-
             The server has not implemented this operation.

--- a/interfaces/interuss/dss/aux/get_from_upstream.sh
+++ b/interfaces/interuss/dss/aux/get_from_upstream.sh
@@ -11,6 +11,7 @@ fi
 cd "${BASEDIR}" || exit
 
 # URL to raw content for this interface.  Should target pinned content: either a tag or commit.
-URL="https://raw.githubusercontent.com/interuss/dss/refs/tags/interuss/dss/v0.21.1/interfaces/aux_/aux_.yaml"
+# URL="https://raw.githubusercontent.com/interuss/dss/refs/tags/interuss/dss/v0.21.1/interfaces/aux_/aux_.yaml"
+URL="https://raw.githubusercontent.com/interuss/dss/05165589f47f3f70e3fbef39f8f2173c34a97719/interfaces/aux_/aux_.yaml"
 
 wget -N $URL

--- a/src/uas_standards/interuss/dss/aux/api.py
+++ b/src/uas_standards/interuss/dss/aux/api.py
@@ -42,7 +42,7 @@ class Heartbeat(ImplicitDict):
     index: int | None = 0
     """Index of this heartbeat within the set of all heartbeats for this pool participant."""
 
-    next_heartbeat_expected_before: StringBasedDateTime | None = StringBasedDateTime("")
+    next_heartbeat_expected_before: StringBasedDateTime | None
     """The time by which a new heartbeat should be registered for this DSS instance if the DSS instance operator's system is behaving correctly."""
 
 
@@ -167,6 +167,8 @@ OPERATIONS: dict[OperationID, Operation] = {
         request_body_type=None,
         response_body_type={
             200: SCDLockModeResponse,
+            401: ErrorResponse,
+            403: ErrorResponse,
             501: ErrorResponse,
         },
     ),


### PR DESCRIPTION
This PR imports changes to the `aux` API exposed by InterUSS DSS instances by targeting a commit with the changes in `get_from_upstream.sh` (they are not yet contained in a release), running that script, and then running `make apis`.

The primary motivation for this update is to fix the invalid `StringBasedDateTime("")` initialization value that makes aux/api.py unusable currently.